### PR TITLE
Use builtin urllib.parse.urlencode for users query

### DIFF
--- a/splitcli/split_apis/users_api.py
+++ b/splitcli/split_apis/users_api.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from splitcli.split_apis import http_client
 
 # URLs
@@ -33,15 +35,15 @@ def list_users(status=None,group_id=None):
 
 def list_users_batch(next=None, status=None, group_id=None):
     path = users_url()
-    query = ""
+    query = {}
     if next is not None:
-        query += f"after={next}"
+        query["after"] = next
     if status is not None:
-        query += f"status={status}"
+        query["status"] = status
     if group_id is not None:
-        query += f"group_id={group_id}"
-    if len(query) > 0:
-        path += f"?{query}"
+        query["group_id"] = group_id
+    if query:
+        path += f"?{urlencode(query)}"
     return http_client.get(path)
 
 def get_user_by_email(email):


### PR DESCRIPTION
## Description

Swapped out the string concatenation logic with urlencode.

## Related Issue

Let me know if you would prefer I make an issue for this first, but this fixes a bug I had running the CLI where upon entering my admin API key on login, the following was raised:

```python
RuntimeError: Error with request: url=https://api.split.io/internal/api/v2/users?after=<truncated_string_of_chars>status=ACTIVE payload=None code=400 result={'code': 400, 'message': 'Input byte array has wrong 4-byte ending unit', 'details': '', 'transactionId': '...'}
```

## Motivation and Context

As the [docs for urlencode](https://docs.python.org/3.6/library/urllib.parse.html?highlight=urlencode#urllib.parse.urlencode) suggest, it seems like a good candidate given what is being accomplished in `list_users_batch`.

## Testing

Ran the CLI locally with this change and was able to successfully log in.