### PR TITLE
Update offset when looping over results in queries

### DIFF
--- a/splitcli/split_apis/segments_api.py
+++ b/splitcli/split_apis/segments_api.py
@@ -36,6 +36,8 @@ def list_segments(workspace_id):
             all_segments.extend(result)
         else:
             break
+        offset += limit
+
     return all_segments
 
 def list_segments_batch(workspace_id, offset, limit):
@@ -52,6 +54,8 @@ def list_segments_environment(workspace_id, environment_name):
             all_segments.extend(result)
         else:
             break
+        offset += limit
+            
     return all_segments
 
 def list_segments_environment_batch(workspace_id, environment_name, offset, limit):

--- a/splitcli/split_apis/splits_api.py
+++ b/splitcli/split_apis/splits_api.py
@@ -25,6 +25,8 @@ def list_splits(workspace_id):
             all_splits.extend(result)
         else:
             break
+        offset += limit
+
     return all_splits
 
 def list_splits_batch(workspace_id, offset, limit):


### PR DESCRIPTION
## Description

See title.

## Related Issue

As with #6, Let me know if you would prefer I make an issue for this first, but this fixes a bug I had running the CLI where when trying to fetch either split or segment list, a runtime error was encountered.

```python
RuntimeError: Error with request: url=https://api.split.io/internal/api/v2/splits/ws/<ws_id>?offset=0&limit=20 payload=None code=429 result={'code': 429, 'message': '', 'details': '', 'transactionId': '...'}
```

The issue is reproducible if the list of segments/splits in your workspace exceeds the default limit (20).

## Motivation and Context

The same results were being returned on each loop because offset was not being updated, thus the loop never exits, thus the rate limit response.

## Testing

Ran the CLI locally with this change and was able to successfully fetch both segments and splits. After that point, rest of the CLI worked like a charm 🎉 . Thanks for creating this!!!